### PR TITLE
Add option to set working directory for 'npm install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ _Run this task with the `grunt install-dependencies` command._
 
 There are a number of options available.
 
+#### options.cwd
+Type: `String`
+Default: ''
+
+Defines the working directory to run 'npm install' (relative path)
+
 #### options.stdout
 Type: `Boolean`
 Default: true

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ _Run this task with the `grunt install-dependencies` command._
 
 There are a number of options available.
 
-#### options.cwd
-Type: `String`
-Default: ''
-
-Defines the working directory to run 'npm install' (relative path)
-
 #### options.stdout
 Type: `Boolean`
 Default: true
@@ -49,3 +43,9 @@ Type: `Boolean`
 Default: true
 
 Instructs the install-dependencies task to fail the grunt run if an error occurs while updating dependencies.
+
+#### options.cwd
+Type: `String`
+Default: (none)  - runs in current directory
+
+Defines the working directory to run 'npm install' (relative path)

--- a/tasks/install-dependencies.js
+++ b/tasks/install-dependencies.js
@@ -8,11 +8,12 @@ module.exports = function (grunt) {
 
 		cb = this.async();
 		options = this.options({
+      cwd: '',
 			stdout: true,
 			stderr: true,
 			failOnError: true
 		});
-		cp = exec('npm install', function (err, stdout, stderr) {
+		cp = exec('npm install', {cwd: options.cwd}, function (err, stdout, stderr) {
 			if (err && options.failOnError) {
 				grunt.warn(err);
 			}
@@ -22,6 +23,7 @@ module.exports = function (grunt) {
 		grunt.verbose.writeflags(options, 'Options');
 
 		if (options.stdout || grunt.option('verbose')) {
+      console.log("Running npm install in: " + options.cwd)
 			cp.stdout.pipe(process.stdout);
 		}
 


### PR DESCRIPTION
Option overrides default of current directory, allowing 'npm install' to be run on a configurable relative path.
