### PR TITLE
Added a isDevelopment option.

### DIFF
--- a/tasks/install-dependencies.js
+++ b/tasks/install-dependencies.js
@@ -11,9 +11,12 @@ module.exports = function (grunt) {
       cwd: '',
       stdout: true,
       stderr: true,
-      failOnError: true
+      failOnError: true,
+      isDevelopment: false
     });
-    cp = exec('npm install', {cwd: options.cwd}, function (err, stdout, stderr) {
+    var cmd = "npm install";
+    if(!options.isDevelopment ) cmd += " -production";
+    cp = exec(cmd, {cwd: options.cwd}, function (err, stdout, stderr) {
       if (err && options.failOnError) {
         grunt.warn(err);
       }


### PR DESCRIPTION
If not in development environment (eg. you have to build a production
tarball) than npm install shoud called with the -procution flag.
