### PR TITLE
Added the isDevelopment option documentation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Default: true
 
 Instructs the install-dependencies task to fail the grunt run if an error occurs while updating dependencies.
 
+#### options.isDevelopment
+Type: `Boolean`
+Default: false
+
+If `false` runs npm install with the -production flag (doesn't install devDependencies). Otherwise install all dependencies
+
 #### options.cwd
 Type: `String`
 Default: (none)  - runs in current directory


### PR DESCRIPTION
Updating from v0.1.0 to v0.2.0 messed up my build and found out that this undocumented option was the cause of the problem
